### PR TITLE
Bumps commons.compress.version to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   </developers>
 
   <properties>
-    <commons.compress.version>1.18</commons.compress.version>
+    <commons.compress.version>1.19</commons.compress.version>
     <xz.version>1.8</xz.version>
     <junit.version>4.11</junit.version>
 


### PR DESCRIPTION
This upgrade fixes a security issue from Snyk

https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-460507